### PR TITLE
Add experimental flag to npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "test": "jest",
-    "start": "node src/server.js"
+    "start": "node --experimental-fetch src/server.js"
   },
   "author": "",
   "license": "MIT"


### PR DESCRIPTION
Otherwise `npm start` does not work.